### PR TITLE
Fix for skipping tests

### DIFF
--- a/t/002_gets.t
+++ b/t/002_gets.t
@@ -9,9 +9,7 @@ Log::Log4perl->easy_init($DEBUG);
 use YAML;
 
 if( not $ENV{PINGBOARD_ACCESS_TOKEN} ){
-    fail( "!!! Environment variable PINGBOARD_ACCESS_TOKEN was not defined, so live tests not being executed !!!" );
-    done_testing();
-    exit(0);
+    plan skip_all => "!!! Environment variable PINGBOARD_ACCESS_TOKEN was not defined, so live tests not being executed !!!";
 }
 
 # Setting more aggressive timeout/backoff/retries so that testing does not take forever


### PR DESCRIPTION
In original code, tests are filed if environment variable `PINGBOARD_ACCESS_TOKEN` is not set.

```
% prove -bv t/002_gets.t
t/002_gets.t .. 
not ok 1 - !!! Environment variable PINGBOARD_ACCESS_TOKEN was not defined, so live tests not being executed !!!
1..1

#   Failed test '!!! Environment variable PINGBOARD_ACCESS_TOKEN was not defined, so live tests not being executed !!!'
#   at t/002_gets.t line 12.
# Looks like you failed 1 test of 1.
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/1 subtests 

Test Summary Report
-------------------
t/002_gets.t (Wstat: 256 Tests: 1 Failed: 1)
  Failed test:  1
  Non-zero exit status: 1
Files=1, Tests=1,  0 wallclock secs ( 0.02 usr  0.00 sys +  0.17 cusr  0.00 csys =  0.19 CPU)
Result: FAIL
```